### PR TITLE
Adding Import-Module instructions for Github usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ Installation
 ------------
 The source code for Revoke-Obfuscation is hosted at Github, and you may download, fork and review it from this repository (https://github.com/danielbohannon/Revoke-Obfuscation). Please report issues or feature requests through Github's bug tracker associated with this project.
 
+To install (from Github):
+
+	Import-Module .\Revoke-Obfuscation.psd1
+
 The source code can also be installed directly from the PowerShell Gallery via the following commands:
 
-To install:
+To install (from PowerShell Gallery):
 
 	Install-Module Revoke-Obfuscation
 	Import-Module Revoke-Obfuscation


### PR DESCRIPTION
Some users have reported extremely poor detection FPs. This potentially stems from downloading the project from Github and importing Revoke-Obfuscation.psm1 instead of Revoke-Obfuscation.psd1. Adding this instruction to the README.