### PR TITLE
change host version for vscode integrated console

### DIFF
--- a/Revoke-Obfuscation.psd1
+++ b/Revoke-Obfuscation.psd1
@@ -53,7 +53,7 @@ Description = 'PowerShell module file for importing all required modules for the
 PowerShellVersion = '3.0'
 
 # Minimum version of the Windows PowerShell host required by this module
-PowerShellHostVersion = '3.0'
+PowerShellHostVersion = '1.6'
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module
 #ScriptsToProcess = @('Get-ScriptBlock.ps1')


### PR DESCRIPTION
```
PS C:\Program Files (x86)\Microsoft VS Code> (gi .\Code.exe).versioninfo

ProductVersion   FileVersion      FileName
--------------   -----------      --------
1.21.1           1.21.1           C:\Program Files (x86)\Microsoft VS Code\Code.exe


PS C:\Program Files (x86)\Microsoft VS Code> get-host


Name             : Visual Studio Code Host
Version          : 1.6.0
InstanceId       : a7215668-5039-4dcb-a92e-7cf389833cae
UI               : System.Management.Automation.Internal.Host.InternalHostUserInterface
CurrentCulture   : en-US
CurrentUICulture : en-US
PrivateData      :
DebuggerEnabled  : True
IsRunspacePushed : False
Runspace         : System.Management.Automation.Runspaces.LocalRunspace
```